### PR TITLE
Feature/77 wire rest endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1760,6 +1760,112 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.14.tgz",
+      "integrity": "sha512-Hz5q8Vu0D288x3iWXePSn53W7hAjP0H7EQ6QvDO9c7t46mR0lNOLlfuwQ+JkVxuhygHzlzPX+0jKdA3ZgSh+Vg==",
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.7",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+          "integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig=="
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -1771,9 +1877,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "14.0.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.24.tgz",
-      "integrity": "sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA=="
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "@types/jest": "^26.0.14",
+    "@types/node": "^14.11.2",
     "autoprefixer": "^9.8.6",
     "classnames": "^2.2.6",
     "env-cmd": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "react-scripts start",
     "mock": "env-cmd -f .env.mock react-scripts start",
-    "build": "env-cmd -f .env.mock react-scripts build",
+    "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "deploy": "aws s3 rm s3://corpsmap-appz/water --recursive && aws s3 cp ./build/ s3://corpsmap-appz/water --recursive"

--- a/src/app-bundles/bundle-utils.js
+++ b/src/app-bundles/bundle-utils.js
@@ -1,3 +1,19 @@
-export function isMockMode() {
+export function isMockMode( forceMockMode ) {
+  if( forceMockMode === true ) return true;
   return process.env.REACT_APP_MOCK_MODE === "true";
+}
+
+export function getMockUrlBase() {
+  return `${ process.env.PUBLIC_URL }/mockdata`;
+}
+
+export function getRestUrl( liveUrl, mockUrl, mockOverrideFlag ) {
+  let useMockUrl = isMockMode();
+  if( mockOverrideFlag === true || mockOverrideFlag === false ) useMockUrl = mockOverrideFlag;
+  const baseUrl = process.env.NODE_ENV === "development"
+    ? useMockUrl ? `${ process.env.PUBLIC_URL }/mockdata` : `http://localhost:3030`
+    : useMockUrl ? `${ process.env.PUBLIC_URL }/mockdata` : `https://api.rsgis.dev/development`;
+
+  if( useMockUrl ) return `${ baseUrl }${ mockUrl }`;
+  else return `${ baseUrl }${ liveUrl }`;
 }

--- a/src/app-bundles/bundle-utils.js
+++ b/src/app-bundles/bundle-utils.js
@@ -7,6 +7,14 @@ export function getMockUrlBase() {
   return `${ process.env.PUBLIC_URL }/mockdata`;
 }
 
+/**
+ * Builds a REST URL. When not in mock mode, it uses the `liveUrl`. In mock mode, uses the `mockUrl`. If the
+ * optional `mockOverrideFlag` is set to true, forces use of the `mockUrl`. If set to false, forces use of the `liveUrl`.
+ * @param liveUrl
+ * @param mockUrl
+ * @param [mockOverrideFlag]
+ * @returns {string}
+ */
 export function getRestUrl( liveUrl, mockUrl, mockOverrideFlag ) {
   let useMockUrl = isMockMode();
   if( mockOverrideFlag === true || mockOverrideFlag === false ) useMockUrl = mockOverrideFlag;

--- a/src/app-bundles/bundle-utils.test.js
+++ b/src/app-bundles/bundle-utils.test.js
@@ -15,7 +15,7 @@ test( "builds REST URL correctly", () => {
   expect( url ).toBe( "http://localhost:3030/water/locations" );
 
   url = getRestUrlTest( true, false, "/water/locations", "/location-list.json", true );
-  expect( url ).toBe( "/water/mockdata/location-list.json" );
+  expect( url ).toBe( `${ process.env.PUBLIC_URL }/mockdata/location-list.json` );
 
   url = getRestUrlTest( true, false, "/water/locations", "/location-list.json", false );
   expect( url ).toBe( "http://localhost:3030/water/locations" );
@@ -24,26 +24,26 @@ test( "builds REST URL correctly", () => {
   expect( url ).toBe( "https://api.rsgis.dev/development/water/locations" );
 
   url = getRestUrlTest( false, false, "/water/locations", "/location-list.json", true );
-  expect( url).toBe( "/water/mockdata/location-list.json" );
+  expect( url).toBe( `${ process.env.PUBLIC_URL }/mockdata/location-list.json` );
 
   url = getRestUrlTest( false, false, "/water/locations", "/location-list.json", false );
   expect( url ).toBe( "https://api.rsgis.dev/development/water/locations" );
 
 
   url = getRestUrlTest( true, true, "/water/locations", "/location-list.json" );
-  expect( url ).toBe( "/water/mockdata/location-list.json" );
+  expect( url ).toBe( `${ process.env.PUBLIC_URL }/mockdata/location-list.json` );
 
   url = getRestUrlTest( true, true, "/water/locations", "/location-list.json", true );
-  expect( url ).toBe( "/water/mockdata/location-list.json" );
+  expect( url ).toBe( `${ process.env.PUBLIC_URL }/mockdata/location-list.json` );
 
   url = getRestUrlTest( true, true, "/water/locations", "/location-list.json", false );
   expect( url ).toBe( "http://localhost:3030/water/locations" );
 
   url = getRestUrlTest( false, true, "/water/locations", "/location-list.json" );
-  expect( url ).toBe( "/water/mockdata/location-list.json" );
+  expect( url ).toBe( `${ process.env.PUBLIC_URL }/mockdata/location-list.json` );
 
   url = getRestUrlTest( false, true, "/water/locations", "/location-list.json", true );
-  expect( url ).toBe( "/water/mockdata/location-list.json" );
+  expect( url ).toBe( `${ process.env.PUBLIC_URL }/mockdata/location-list.json` );
 
   url = getRestUrlTest( false, true, "/water/locations", "/location-list.json", false );
   expect( url ).toBe( "https://api.rsgis.dev/development/water/locations" );

--- a/src/app-bundles/bundle-utils.test.js
+++ b/src/app-bundles/bundle-utils.test.js
@@ -1,0 +1,50 @@
+// Mock method with same logic as original, but allows for forcing dev vs. prod mode detection
+function getRestUrlTest( isDev, isMockEnv, liveUrl, mockUrl, mockOverrideFlag ) {
+  let useMockUrl = isMockEnv; // Real function uses isMockMode() and mock NODE_ENV flag
+  if( mockOverrideFlag === true || mockOverrideFlag === false ) useMockUrl = mockOverrideFlag;
+  const baseUrl = isDev // Real function uses: process.env.NODE_ENV === "development"
+    ? useMockUrl ? `${ process.env.PUBLIC_URL }/mockdata` : `http://localhost:3030`
+    : useMockUrl ? `${ process.env.PUBLIC_URL }/mockdata` : `https://api.rsgis.dev/development`;
+
+  if( useMockUrl ) return `${ baseUrl }${ mockUrl }`;
+  else return `${ baseUrl }${ liveUrl }`;
+}
+
+test( "builds REST URL correctly", () => {
+  let url = getRestUrlTest( true, false, "/water/locations", "/location-list.json" );
+  expect( url ).toBe( "http://localhost:3030/water/locations" );
+
+  url = getRestUrlTest( true, false, "/water/locations", "/location-list.json", true );
+  expect( url ).toBe( "/water/mockdata/location-list.json" );
+
+  url = getRestUrlTest( true, false, "/water/locations", "/location-list.json", false );
+  expect( url ).toBe( "http://localhost:3030/water/locations" );
+
+  url = getRestUrlTest( false, false, "/water/locations", "/location-list.json" );
+  expect( url ).toBe( "https://api.rsgis.dev/development/water/locations" );
+
+  url = getRestUrlTest( false, false, "/water/locations", "/location-list.json", true );
+  expect( url).toBe( "/water/mockdata/location-list.json" );
+
+  url = getRestUrlTest( false, false, "/water/locations", "/location-list.json", false );
+  expect( url ).toBe( "https://api.rsgis.dev/development/water/locations" );
+
+
+  url = getRestUrlTest( true, true, "/water/locations", "/location-list.json" );
+  expect( url ).toBe( "/water/mockdata/location-list.json" );
+
+  url = getRestUrlTest( true, true, "/water/locations", "/location-list.json", true );
+  expect( url ).toBe( "/water/mockdata/location-list.json" );
+
+  url = getRestUrlTest( true, true, "/water/locations", "/location-list.json", false );
+  expect( url ).toBe( "http://localhost:3030/water/locations" );
+
+  url = getRestUrlTest( false, true, "/water/locations", "/location-list.json" );
+  expect( url ).toBe( "/water/mockdata/location-list.json" );
+
+  url = getRestUrlTest( false, true, "/water/locations", "/location-list.json", true );
+  expect( url ).toBe( "/water/mockdata/location-list.json" );
+
+  url = getRestUrlTest( false, true, "/water/locations", "/location-list.json", false );
+  expect( url ).toBe( "https://api.rsgis.dev/development/water/locations" );
+});

--- a/src/app-bundles/corporate-office-bundle.js
+++ b/src/app-bundles/corporate-office-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,7 @@ export default createRestBundle({
   staleAfter: 10000,
   persist: false,
   routeParam: "corpOfficeSlug",
-  getTemplate: isMockMode() ? "/offices.json" : "/water/locations/offices",
+  getTemplate: getRestUrl( "/water/locations/offices", "/offices.json" ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/corporate-office-location-report-bundle.js
+++ b/src/app-bundles/corporate-office-location-report-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,10 @@ export default createRestBundle({
   staleAfter: 0,
   persist: false,
   routeParam: "corpOfficeSlug",
-  getTemplate: isMockMode() ? "/corporate-office-location-reports.json?:corpOfficeSlug" : "/water/locations/offices/:corpOfficeSlug/reports",
+  getTemplate: getRestUrl(
+    "/water/locations/offices/:corpOfficeSlug/reports",
+    "/corporate-office-location-reports.json?:corpOfficeSlug",
+    true ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/corporate-office-report-bundle.js
+++ b/src/app-bundles/corporate-office-report-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,10 @@ export default createRestBundle({
   staleAfter: 0,
   persist: false,
   routeParam: "corpOfficeSlug",
-  getTemplate: isMockMode() ? "/corporate-office-reports.json?:corpOfficeSlug" : "/water/locations/offices/:corpOfficeSlug/reports",
+  getTemplate: getRestUrl(
+    "/water/locations/offices/:corpOfficeSlug/reports",
+    "/corporate-office-reports.json?:corpOfficeSlug",
+    true ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/corporate-office-special-report-bundle.js
+++ b/src/app-bundles/corporate-office-special-report-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,10 @@ export default createRestBundle({
   staleAfter: 0,
   persist: false,
   routeParam: "corpOfficeSlug",
-  getTemplate: isMockMode() ? "/corporate-office-special-reports.json?:corpOfficeSlug" : "/water/locations/offices/:corpOfficeSlug/reports",
+  getTemplate: getRestUrl(
+    "/water/locations/offices/:corpOfficeSlug/reports",
+    "/corporate-office-special-reports.json?:corpOfficeSlug",
+    true ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/district-reports-bundle.js
+++ b/src/app-bundles/district-reports-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,10 @@ export default createRestBundle({
   staleAfter: 0,
   persist: false,
   //routeParam: "",
-  getTemplate: isMockMode() ? "/district-reports.json" : "/water/reports/DistrictReports",
+  getTemplate: getRestUrl(
+    "/water/reports/DistrictReports",
+    "/district-reports.json",
+    true ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/districts-and-basins-bundle.js
+++ b/src/app-bundles/districts-and-basins-bundle.js
@@ -1,25 +1,25 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
-export default createRestBundle({
+export default createRestBundle( {
   name: "districtsAndBasins",
   uid: "basin_location_code",
   prefetch: true,
   staleAfter: 10000,
   persist: false,
   //routeParam: "districtsAndBasinsSlug",
-  getTemplate: isMockMode() ? "/districts-and-basins.json" : "/water/locations/basins",
+  getTemplate: getRestUrl( "/water/locations/basins", "/districts-and-basins.json" ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,
   fetchActions: [],
   forceFetchActions: [],
-  reduceFurther: (state, { type, payload }) => {
-    switch (type) {
+  reduceFurther: ( state, { type, payload } ) => {
+    switch( type ) {
       case "SET_SELECTED_DISTRICT_ID":
       case "SET_SELECTED_BASIN_ID":
-        return Object.assign({}, state, payload);
+        return Object.assign( {}, state, payload );
       default:
         return state;
     }
@@ -27,48 +27,48 @@ export default createRestBundle({
   addons: {
     selectDistricts: createSelector(
       "selectDistrictsAndBasinsItems",
-      (districtsAndBasins) => {
+      ( districtsAndBasins ) => {
         // TODO: We could add lodash which has array unique function as well as many other utility functions?
         const matchedDistrictIds = {};
-        const result = districtsAndBasins.filter(entry => {
-          if (matchedDistrictIds[entry.district_office_id]) return false;
-          matchedDistrictIds[entry.district_office_id] = true;
+        const result = districtsAndBasins.filter( entry => {
+          if( matchedDistrictIds[ entry.district_office_id ] ) return false;
+          matchedDistrictIds[ entry.district_office_id ] = true;
           return true;
-        });
-        return result;
+        } );
+        return result.sort( ( a, b ) => ( a.district_name > b.district_name ) ? 1 : -1 );
       }
     ),
     selectBasinsForDistrict: createSelector(
       "selectDistrictsAndBasinsItems",
       "selectSelectedDistrict",
-      (districtsAndBasins, selectedDistrict) => {
-        if(!selectedDistrict) return districtsAndBasins;
-        const result = districtsAndBasins.filter(entry => entry.district_office_id === selectedDistrict)
-        return result;
+      ( districtsAndBasins, selectedDistrict ) => {
+        if( !selectedDistrict ) return districtsAndBasins;
+        const result = districtsAndBasins.filter( entry => entry.district_office_id === selectedDistrict )
+        return result.sort( ( a, b ) => ( a.basin_name > b.basin_name ) ? 1 : -1 );;
       }
     ),
-    doSetSelectedDistrict: (id) => ({ dispatch }) => {
-      dispatch({
+    doSetSelectedDistrict: ( id ) => ( { dispatch } ) => {
+      dispatch( {
         type: "SET_SELECTED_DISTRICT_ID",
         payload: {
           _district_office_id: id,
           _basin_location_id: null
         },
-      });
+      } );
     },
-    doSetSelectedBasin: (id) => ({ dispatch }) => {
-      dispatch({
+    doSetSelectedBasin: ( id ) => ( { dispatch } ) => {
+      dispatch( {
         type: "SET_SELECTED_BASIN_ID",
         payload: {
           _basin_location_id: id,
         },
-      });
+      } );
     },
-    selectSelectedDistrict: (state) => {
+    selectSelectedDistrict: ( state ) => {
       return state.districtsAndBasins._district_office_id;
     },
-    selectSelectedBasin: (state) => {
+    selectSelectedBasin: ( state ) => {
       return state.districtsAndBasins._basin_location_id;
     },
   },
-});
+} );

--- a/src/app-bundles/index.js
+++ b/src/app-bundles/index.js
@@ -33,7 +33,9 @@ export default composeBundles(
     redirectOnLogout: "/",
   }),
   createJwtApiBundle({
-    root: "", // We use the getRestUrl() utility method to build the REST URLs.
+    // `root` will force the use of the URL root across all bundles. Our bundles use the getRestUrl() utility method
+    // to build the REST URLs on a per-bundle basis. This way individual bundles can use either mock or live URLs.
+    root: "",
     unless: {
       method: "GET",
     },

--- a/src/app-bundles/index.js
+++ b/src/app-bundles/index.js
@@ -13,7 +13,6 @@ import createAuthBundle from "@corpsmap/create-auth-bundle";
 import createJwtApiBundle from "@corpsmap/create-jwt-api-bundle";
 import pkg from "../../package.json";
 
-import { isMockMode } from "./bundle-utils";
 import routeBundle from "./routes-bundle";
 import mapsBundle from "./maps-bundle";
 import mapsPageBundle from "./map-page-bundle";
@@ -34,10 +33,7 @@ export default composeBundles(
     redirectOnLogout: "/",
   }),
   createJwtApiBundle({
-    root:
-      process.env.NODE_ENV === "development"
-        ? isMockMode() ? `${ process.env.PUBLIC_URL }/mockdata` : `https://api.rsgis.dev/development`
-        : isMockMode() ? `${ process.env.PUBLIC_URL }/mockdata` : `https://api.rsgis.dev/development`,
+    root: "", // We use the getRestUrl() utility method to build the REST URLs.
     unless: {
       method: "GET",
     },

--- a/src/app-bundles/map-page-bundle.js
+++ b/src/app-bundles/map-page-bundle.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-mixed-operators */
 // import { createSelector } from "redux-bundler";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 // import { isValidArrWithValues } from "../functions";
 import olMap from "ol/Map.js";
 import View from "ol/View";
@@ -32,9 +32,7 @@ export default {
 
   getReducer: () => {
     const initialData = {
-      url: isMockMode()
-        ? `${ process.env.PUBLIC_URL }/mockdata/location-list.json`
-        : "/api/location-list",
+      url: getRestUrl( "/water/locations", "/location-list.json" )
       // shouldFetch: false,
       // error: null,
       // hasLoaded: false,
@@ -218,11 +216,19 @@ export default {
       if (feature) {
         const geometry = feature.getGeometry();
         const coord = geometry.getCoordinates();
-        const featureProp = feature.getProperties().features && feature.getProperties().features[0] && feature.getProperties().features[0].description;
+        const featureProperties = feature.getProperties();
+        let displayedFeature = feature;
 
-        let content =  featureProp &&
-          "<h5>" + feature.getProperties().features[0].description + "</h5>";
-        content += featureProp && '<p>' + feature.getProperties().features[0].longLat + '</p>';
+        // Feature can already be a specific location, or a cluster of features.
+        if( Array.isArray( featureProperties.features ) ) {
+          if( featureProperties.features.length > 0 ) displayedFeature = featureProperties.features[ 0 ]
+          else return;
+        }
+
+        //const featureProp = featureProperties.features && featureProperties.features[0] && featureProperties.features[0].description;
+
+        let content =  "<h5>" + displayedFeature.description + "</h5>";
+        content += '<p>' + displayedFeature.longLat + '</p>';
         contentContainer.innerHTML = content;
         overlay.setPosition(coord);
       }

--- a/src/app-bundles/project-reports-bundle.js
+++ b/src/app-bundles/project-reports-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,10 @@ export default createRestBundle({
   staleAfter: 0,
   persist: false,
   //routeParam: "",
-  getTemplate: isMockMode() ? "/project-reports.json" : "/water/reports/ProjectReports",
+  getTemplate: getRestUrl(
+    "/water/reports/ProjectReports",
+    "/project-reports.json",
+    true ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/watershed-reports-bundle.js
+++ b/src/app-bundles/watershed-reports-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { isMockMode } from "./bundle-utils";
+import { getRestUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,10 @@ export default createRestBundle({
   staleAfter: 0,
   persist: false,
   //routeParam: "",
-  getTemplate: isMockMode() ? "/watershed-reports.json" : "/water/reports/WatershedReports",
+  getTemplate: getRestUrl(
+    "/water/reports/WatershedReports",
+    "/watershed-reports.json",
+    true ),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-components/Footer/test/Footer.test.js
+++ b/src/app-components/Footer/test/Footer.test.js
@@ -8,7 +8,7 @@ import Footer from "../index";
 import { findByTestAttr } from "../../../testUtils";
 
 // Set up the component with props:
-const initialSetup = (children) => {
+const initialSetup = (props) => {
   const wrapper = shallow(
     <Footer {...props} />
   );

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,74 @@
+{
+  "include": [
+    "src",
+    "typings"
+  ],
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "allowJs": true,                          /* Allow javascript files to be compiled. */
+    "checkJs": true,                          /* Report errors in .js files. */
+    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "resolveJsonModule": true,
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true,                           /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": false,                          /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
#77 enable live REST URLs for some bundles. Using a global URL root applies that root URL to all bundles, so switch over to using a helper function so that REST URLs are configurable per-bundle (each bundle can individually use a live or mock JSON URL). 