### PR TITLE
add proxy to package.json so that frontend can access the backend endpoints when running the frontend locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "https://apps.rsgis.dev/water",
+  "proxy": "https://api.rsgis.dev/development",
   "dependencies": {
     "@corpsmap/corpsmap-bundles": "^2.0.2",
     "@corpsmap/create-auth-bundle": "^0.3.0",

--- a/src/app-bundles/bundle-utils.js
+++ b/src/app-bundles/bundle-utils.js
@@ -11,6 +11,8 @@ export function isDevelopmentMode() {
   return process.env.NODE_ENV !== "production";
 }
 
+export const prodUrl = "https://api.rsgis.dev/development";
+
 /**
  * Builds a REST URL. When not in mock mode, it uses the `liveUrl`. In mock mode, uses the `mockUrl`. If the
  * optional `mockOverrideFlag` is set to true, forces use of the `mockUrl`. If set to false, forces use of the `liveUrl`.

--- a/src/app-bundles/corporate-office-bundle.js
+++ b/src/app-bundles/corporate-office-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { getRestUrl } from "./bundle-utils";
+import { prodUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 import { RoutePaths } from "./routes-bundle";
 
@@ -10,7 +10,7 @@ export default createRestBundle({
   staleAfter: 10000,
   persist: true,
   routeParam: "corpOfficeId",
-  getTemplate: getRestUrl( "/water/locations/offices", "/offices.json" ),
+  getTemplate: `${ prodUrl }/water/locations/offices`,
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/districts-and-basins-bundle.js
+++ b/src/app-bundles/districts-and-basins-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { getRestUrl } from "./bundle-utils";
+import { prodUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle( {
@@ -8,7 +8,7 @@ export default createRestBundle( {
   prefetch: true,
   staleAfter: 10000,
   persist: false,
-  getTemplate: getRestUrl( "/water/locations/basins", "/districts-and-basins.json" ),
+  getTemplate: `${ prodUrl }/water/locations/basins`,
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,

--- a/src/app-bundles/location-summaries-bundle.js
+++ b/src/app-bundles/location-summaries-bundle.js
@@ -1,5 +1,5 @@
 import createRestBundle from "./create-rest-bundle";
-import { getRestUrl } from "./bundle-utils";
+import { prodUrl } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
 
 export default createRestBundle({
@@ -9,7 +9,7 @@ export default createRestBundle({
   staleAfter: 10000,
   persist: false,
   //routeParam: "",
-  getTemplate: getRestUrl("/water/locations", "/location-list.json"),
+  getTemplate: `${ prodUrl }/water/locations`,
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,


### PR DESCRIPTION
Using this `proxy` that's built into create-react-app, when running the frontend locally it can access the backend endpoints. https://create-react-app.dev/docs/proxying-api-requests-in-development/

If you pull the branch make sure you're on the booz vpn and restart the frontend. This way we don't have to use the mock files when running the frontend locally (at least for the endpoints which are already up and running).