### PR TITLE
refactor to only fetch the locationParams when the maps page loads, instead of after every time the location detail is updated

### DIFF
--- a/src/app-bundles/radar-time-series-bundle.js
+++ b/src/app-bundles/radar-time-series-bundle.js
@@ -29,8 +29,8 @@ export default createRestBundle( {
     ),
     selectLocationTimeSeriesPlotlyData: createSelector(
       "selectLocationTimeSeriesData",
-      "selectLocationParams",
-      (locationTimeSeriesData, locationParams) => {
+      "selectLocationParamsData",
+      (locationTimeSeriesData, locationParamsData) => {
         if (!locationTimeSeriesData || !locationTimeSeriesData["time-series"] || !locationTimeSeriesData["time-series"]["time-series"]) {
           return [];
         }
@@ -57,7 +57,7 @@ export default createRestBundle( {
             });
 
             plotlyData.push({
-              name: locationParams ? formatTimeSeriesName( element.name,locationParams ) : element.name,
+              name: locationParamsData ? formatTimeSeriesName( element.name, locationParamsData ) : element.name,
               x: xData,
               y: yData,
               unit: element["regular-interval-values"].unit,

--- a/src/app-bundles/radar-time-series-params-bundle.js
+++ b/src/app-bundles/radar-time-series-params-bundle.js
@@ -1,8 +1,6 @@
 import createRestBundle from "./create-rest-bundle";
-import { getRestUrl } from "./bundle-utils";
+import { getRestUrl, arrayToObj } from "./bundle-utils";
 import { createSelector } from "redux-bundler";
-
-export const  LOCATION_FORMAT_PARAM_OBJECT = " LOCATION_FORMAT_PARAM_OBJECT";
 
 export default createRestBundle({
   name: "locationParams",
@@ -10,30 +8,31 @@ export default createRestBundle({
   prefetch: false,
   staleAfter: 0,
   persist: false,
-  getTemplate: getRestUrl("http://cwms-data.usace.army.mil/cwms-data/parameters?format=json", "/radar-params.json"),
+  getTemplate: getRestUrl("https://cwms-data.usace.army.mil/cwms-data/parameters?format=json", "/radar-params.json"),
   putTemplate: null,
   postTemplate: null,
   deleteTemplate: null,
-  fetchActions: ["LOCATIONDETAIL_FETCH_FINISHED"],
   forceFetchActions: [],
-  urlParamSelectors: ["selectLocationParams"],
   addons: {
-    selectLocationParams: createSelector(
+    reactLocationParamsFormatData: createSelector(
       "selectLocationParamsData",
       (locationParamsData) => {
-        if (!locationParamsData) return null;
-          return structureParamsData(locationParamsData.parameters.parameters);
+        if (locationParamsData && locationParamsData.parameters && locationParamsData.parameters.parameters) {
+          return {
+            actionCreator: "doLocationParamsFormatData",
+            args: [locationParamsData.parameters.parameters],
+          };
+        }
       }
     ),
+    doLocationParamsFormatData: (parameters) => {
+      const parametersByName = arrayToObj(parameters, "name");
+      return {
+        type: "LOCATIONPARAMS_UPDATED_ITEM",
+        payload: {
+          data: parametersByName,
+        },
+      };
+    },
   },
 });
-
-//returns an obj where the key is the name and the value is the object
-const structureParamsData = (arr) => {
-  const results = {};
-  arr.map((item) => {
-    results[item.name] = item;
-  });
-  return results;
-};
-

--- a/src/app-pages/map/MapPage.js
+++ b/src/app-pages/map/MapPage.js
@@ -4,12 +4,16 @@ import MapDetails from "./components/map-details/MapDetails";
 import LocationsMap from '../../app-common/map/LocationsMap';
 import { connect } from "redux-bundler-react";
 
-const MapPage = ( {doLocationSummariesFetch }) => {
+const MapPage = ({
+  doLocationSummariesFetch,
+  doLocationParamsFetch,
+}) => {
   const opts = { center: [-95, 38.895], zoom: 5 };
 
   useEffect(() => {
     doLocationSummariesFetch();
-  }, [doLocationSummariesFetch])
+    doLocationParamsFetch();
+  }, [doLocationSummariesFetch, doLocationParamsFetch])
 
   return (
     <main>
@@ -33,5 +37,6 @@ const MapPage = ( {doLocationSummariesFetch }) => {
 
 export default connect(
   "doLocationSummariesFetch",
+  "doLocationParamsFetch",
   MapPage
 )


### PR DESCRIPTION
This is what I meant during scrum, right now the locationParams are fetched after every `LOCATIONDETAIL_FETCH_FINISHED`, but it seems like the response will always be the same since we're not changing the url params. If that is the case, then it'd be more efficient to call doLocationParamsFetch only once when the map page is initially rendered, similar to the way we call doLocationSummariesFetch. I didn't change the persist to true so the call will still happen every time you go to the map page. What do you guys think?