### PR TITLE
#147 map bugs

### DIFF
--- a/public/mockdata/location-detail.json
+++ b/public/mockdata/location-detail.json
@@ -11,6 +11,7 @@
   "nearest_city": "",
   "location_code": "1123020",
   "location_id": "Indian Rock",
+  "stream_location_code":"10409020",
   "latitude": 39.92263,
   "longitude": -76.753815,
   "division_id": 4,

--- a/src/app-common/map/LocationsMap.js
+++ b/src/app-common/map/LocationsMap.js
@@ -1,7 +1,7 @@
 import React, { useRef, useCallback } from 'react';
 import PropTypes from "prop-types";
 import { connect } from "redux-bundler-react";
-import { Tile as TileLayer, Vector as VectorLayer } from "ol/layer";
+import { Vector as VectorLayer } from "ol/layer";
 import Feature from "ol/Feature";
 import Point from "ol/geom/Point";
 import Overlay from "ol/Overlay";
@@ -13,7 +13,7 @@ import {
   Text,
   Icon,
 } from "ol/style";
-import { Cluster, OSM, Vector as VectorSource } from "ol/source";
+import { Cluster, Vector as VectorSource } from "ol/source";
 import { fromLonLat, toLonLat } from "ol/proj";
 import MapContainer from "./MapContainer";
 
@@ -112,10 +112,6 @@ const LocationsMap = (props) => {
       minResolution: 201,
     });
 
-    const raster = new TileLayer({
-      source: new OSM(),
-    });
-
     const overlay = new Overlay({
       element: popupContainer.current,
       positioning: "bottom-center",
@@ -126,7 +122,7 @@ const LocationsMap = (props) => {
 
     //add data points to map obj
     map.addOverlay(overlay);
-    map.addLayer(raster);
+    // Base layer is automatically added by basemap-picker
     map.addLayer(clusters);
     map.addLayer(unclusteredLayer);
 

--- a/src/ol-controls/basemap-picker.js
+++ b/src/ol-controls/basemap-picker.js
@@ -13,6 +13,7 @@ const basemaps = [
     attributions:
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
   },
+  /* These are invalid. Either remove, or update URL and/or token.
   {
     id: "MapBoxStreets",
     name: "MapBox Streets",
@@ -28,7 +29,7 @@ const basemaps = [
       "https://api.tiles.mapbox.com/v4/willbreitkreutzwork.pki0cla6/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoidXNhY2UiLCJhIjoiY2o1MDZscms4MDI4MjMycG1wa3puc212MCJ9.CW7edZMtlx5vFLNF5P-zTA",
     attributions:
       'Imagery from <a href="https://mapbox.com/about/maps/">MapBox</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
-  },
+  },*/
   {
     id: "MapBoxOutdoor",
     name: "MapBox Outdoor",
@@ -118,22 +119,24 @@ class BasemapControl extends Control {
     const options = Object.assign(
       {
         basemaps: basemaps.map((b) => {
-          return new XYZ({
+          // Build layer configs that can be used to create XYZ layers later.
+          return {
             url: b.url,
             crossOrigin: true,
             attributions: b.attributions,
             maxZoom: b.maxZoom,
-          });
+          };
         }),
         activeIdx: 0,
       },
       props
-    );
+   );
 
     const layer = new Tile({
-      source: options.basemaps[options.activeIdx],
+      source: new XYZ(options.basemaps[options.activeIdx]),
     });
 
+    // Build Select element and Options for each basemap item
     var select = document.createElement("select");
     basemaps.forEach((b, i) => {
       const opt = document.createElement("option");
@@ -143,6 +146,7 @@ class BasemapControl extends Control {
     });
     select.value = options.activeIdx;
 
+    // Add Select element to DOM
     var element = document.createElement("div");
     element.className = "basemap-control";
     element.appendChild(select);
@@ -157,20 +161,22 @@ class BasemapControl extends Control {
     this.setBasemap = this.setBasemap.bind(this);
 
     select.addEventListener("change", (e) => {
-      this.setBasemap(Number( ( /** @type {HTMLSelectElement} */ ( e.target ) ).value));
+      this.setBasemap(Number((/** @type {HTMLSelectElement} */ (e.target)).value));
     });
   }
 
   setMap(map) {
     super.setMap(map);
-    this.setBasemap(1);
+    this.setBasemap(0);
   }
 
   setBasemap(idx) {
     const map = ( /** @type {Control} */ ( this ) ).getMap();
     map.removeLayer(this.layer);
-    this.layer.setSource(this.options.basemaps[idx]);
+    // Build a new XYZ layer for the selected layer config.
+    this.layer.setSource(new XYZ(this.options.basemaps[idx]));
     map.getLayers().insertAt(0, this.layer);
+    this.options.activeIdx = idx;
   }
 }
 


### PR DESCRIPTION
Ensure only 1 base map layer is used at once; delay creating new XYZ Layer objects until they are actually needed; remove invalid base layer options until they can be updated or removed.