### PR TITLE
Wire up stream controls

### DIFF
--- a/.env.remote
+++ b/.env.remote
@@ -1,0 +1,1 @@
+REACT_APP_REMOTE_MODE=true

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "start": "react-scripts start",
     "mock": "env-cmd -f .env.mock react-scripts start",
+    "remote": "env-cmd -f .env.remote react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/app-bundles/bundle-utils.js
+++ b/src/app-bundles/bundle-utils.js
@@ -3,6 +3,10 @@ export function isMockMode( forceMockMode ) {
   return process.env.REACT_APP_MOCK_MODE === "true";
 }
 
+export function isRemoteMode() {
+  return process.env.REACT_APP_REMOTE_MODE === "true";
+}
+
 export function getMockUrlBase() {
   return `${ process.env.PUBLIC_URL }/mockdata`;
 }
@@ -22,7 +26,7 @@ export function isDevelopmentMode() {
 export function getRestUrl( liveUrl, mockUrl, mockOverrideFlag ) {
   let useMockUrl = isMockMode();
   if( mockOverrideFlag === true || mockOverrideFlag === false ) useMockUrl = mockOverrideFlag;
-  const baseUrl = isDevelopmentMode()
+  const baseUrl = isDevelopmentMode() && !isRemoteMode()
     ? useMockUrl ? `${ process.env.PUBLIC_URL }/mockdata` : `http://localhost:3030`
     : useMockUrl ? `${ process.env.PUBLIC_URL }/mockdata` : `https://api.rsgis.dev/development`;
 

--- a/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
+++ b/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
@@ -10,7 +10,6 @@ const LocationStreamControls = ({
   streamLocationsData,
   doLocationsMapSaveMapState,
   doStreamLocationsFetch,
-  doLocationDetailSetCode,
   doUpdateUrl
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -38,7 +37,6 @@ const LocationStreamControls = ({
       const newLocation = `${RoutePaths.Locations.replace(":locationId", nextLocation.location_code)}`;
       setCurrentIndex( e.target.value );
       doUpdateUrl( newLocation );
-      doLocationDetailSetCode( nextLocation.location_code );
     }
   };
 
@@ -116,7 +114,6 @@ export default connect(
   "selectStreamLocationsData",
   "doLocationsMapSaveMapState",
   "doStreamLocationsFetch",
-  "doLocationDetailSetCode",
   "doUpdateUrl",
   LocationStreamControls
 );

--- a/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
+++ b/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
@@ -78,6 +78,7 @@ const LocationStreamControls = ({
             className="jump-station"
             aria-labelledby="jump to station dropdown"
             onChange={jumpStation}
+            onClick={e => e.stopPropagation()}
             value={currentIndex}
           >
             { streamLocationsData.map((item, i) => (

--- a/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
+++ b/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
@@ -10,6 +10,8 @@ const LocationStreamControls = ({
   streamLocationsData,
   doLocationsMapSaveMapState,
   doStreamLocationsFetch,
+  doLocationDetailSetCode,
+  doUpdateUrl
 }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -26,15 +28,22 @@ const LocationStreamControls = ({
     );
   }, [locationDetailData, streamLocationsData, setCurrentIndex])
 
-  const changeStation = (e) => {
+  const changeStation = ( e, newIndex ) => {
     e.preventDefault();
     e.stopPropagation();
+
+    let nextLocation = streamLocationsData[ newIndex ];
+
+    if( nextLocation ) {
+      const newLocation = `${RoutePaths.Locations.replace(":locationId", nextLocation.location_code)}`;
+      setCurrentIndex( e.target.value );
+      doUpdateUrl( newLocation );
+      doLocationDetailSetCode( nextLocation.location_code );
+    }
   };
 
   const jumpStation = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    setCurrentIndex(e.target.value);
+    changeStation( e, e.currentTarget.value );
   };
 
   const saveMapState = () => {
@@ -59,14 +68,18 @@ const LocationStreamControls = ({
       )}
       { streamLocationsData && streamLocationsData.length > 0 && (
         <div className="location-stream-controls-wrapper">
-          <button className="link downstream-station" onClick={changeStation}>
-            downstream station
-          </button>
+
+          { currentIndex > 0 && (
+            <button className="link downstream-station"
+                    onClick={ ( e ) => changeStation( e, currentIndex - 1 ) }>
+              upstream station
+            </button>
+          )}
+
           <select
             className="jump-station"
             aria-labelledby="jump to station dropdown"
             onChange={jumpStation}
-            onClick={jumpStation}
             value={currentIndex}
           >
             { streamLocationsData.map((item, i) => (
@@ -79,9 +92,14 @@ const LocationStreamControls = ({
               ))
             }
           </select>
-          <button className="link upstream-station" onClick={changeStation}>
-            upstream station
-          </button>
+
+          { currentIndex + 1 < streamLocationsData.length && (
+            <button className="link upstream-station"
+                    onClick={ ( e ) => changeStation( e, currentIndex + 1 ) }>
+              downstream station
+            </button>
+          )}
+
         </div>
       )}
     </div>
@@ -98,5 +116,7 @@ export default connect(
   "selectStreamLocationsData",
   "doLocationsMapSaveMapState",
   "doStreamLocationsFetch",
+  "doLocationDetailSetCode",
+  "doUpdateUrl",
   LocationStreamControls
 );

--- a/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
+++ b/src/app-pages/map/components/location-details/components/location-stream-controls/LocationStreamControls.js
@@ -4,14 +4,20 @@ import PropTypes from "prop-types";
 import { RoutePaths } from "../../../../../../app-bundles/route-paths";
 import "./locationStreamControls.scss";
 
-const LocationStreamControls = ({
-  fullScreen,
-  locationDetailData,
-  streamLocationsData,
-  doLocationsMapSaveMapState,
-  doStreamLocationsFetch,
-  doUpdateUrl
-}) => {
+const LocationStreamControls = (props) => {
+
+  const {
+    fullScreen,
+    /** @type a2w.models.LocationDetail */
+    locationDetailData,
+    /** @type a2w.models.StreamLocation[] */
+    streamLocationsData,
+    doLocationsMapSaveMapState,
+    doStreamLocationsFetch,
+    doUpdateUrl
+  } = props;
+
+
   const [currentIndex, setCurrentIndex] = useState(0);
 
   useEffect(() => {
@@ -34,8 +40,8 @@ const LocationStreamControls = ({
     let nextLocation = streamLocationsData[ newIndex ];
 
     if( nextLocation ) {
-      const newLocation = `${RoutePaths.Locations.replace(":locationId", nextLocation.location_code)}`;
-      setCurrentIndex( e.target.value );
+      const newLocation = `${ RoutePaths.Locations.replace(":locationId", nextLocation.location_code) }`;
+      setCurrentIndex( newIndex );
       doUpdateUrl( newLocation );
     }
   };

--- a/src/debug-helpers.js
+++ b/src/debug-helpers.js
@@ -48,7 +48,7 @@ export const useEffectDebugger = (effectHook, dependencies, dependencyNames = []
 export const toTypeDef = ( model, typeName ) => {
   if( !model ) return;
   let result = `/**\n`;
-  result += ` * @typedef ${ typeName }\n`;
+  result += ` * @typedef a2w.models.${ typeName }\n`;
 
   for( const [ key, value ] of Object.entries( model ) ) {
     result += ` * @property {${ typeof value }} ${ key }\n`;

--- a/typings/model-types.js
+++ b/typings/model-types.js
@@ -101,9 +101,9 @@
  * @property {number} current_elevation
  * @property {number} previous_elevation
  * @property {string} elevation_date
- * @property {object} current_stage
- * @property {object} previous_stage
- * @property {object} stage_date
+ * @property {number} current_stage
+ * @property {number} previous_stage
+ * @property {string} stage_date
  * @property {number} current_flow
  * @property {string} flow_date
  * @property {number} current_inflow
@@ -112,32 +112,52 @@
  * @property {string} precipitation_date
  * @property {number} current_storage
  * @property {string} storage_date
- * @property {object} current_drought_storage
- * @property {object} drought_storage_date
- * @property {object} current_surcharge
- * @property {object} surchange_date
- * @property {object} current_top_of_wall_elevation
- * @property {object} top_of_wall_elevation_date
- * @property {object} current_top_of_wall_stage
- * @property {object} top_of_wall_stage_date
- * @property {object} current_rule_curve
- * @property {object} rule_curve_date
- * @property {object} current_power_generation
- * @property {object} power_generation_date
- * @property {object} current_air_temperature
- * @property {object} air_temperature_date
- * @property {object} current_water_temperature
- * @property {object} water_temperature_date
- * @property {object} current_do
- * @property {object} do_date
- * @property {object} current_ph
- * @property {object} ph_date
- * @property {object} current_cond
- * @property {object} cond_date
+ * @property {number} current_drought_storage
+ * @property {string} drought_storage_date
+ * @property {number} current_surcharge
+ * @property {string} surchange_date
+ * @property {number} current_top_of_wall_elevation
+ * @property {number} top_of_wall_elevation_date
+ * @property {number} current_top_of_wall_stage
+ * @property {number} top_of_wall_stage_date
+ * @property {number} current_rule_curve
+ * @property {string} rule_curve_date
+ * @property {number} current_power_generation
+ * @property {string} power_generation_date
+ * @property {number} current_air_temperature
+ * @property {string} air_temperature_date
+ * @property {number} current_water_temperature
+ * @property {string} water_temperature_date
+ * @property {number} current_do
+ * @property {string} do_date
+ * @property {number} current_ph
+ * @property {number} ph_date
+ * @property {number} current_cond
+ * @property {string} cond_date
  * @property {object} channel_capacity
- * @property {object} spillway_crest
+ * @property {number} spillway_crest
  * @property {string} vertical_datum
- * @property {object} drainage_area
+ * @property {number} drainage_area
  * @property {number} public_ind
- * @property {a2w.models.DamProfile} dam_profile
- */
+ * @property {string} stream_location_code
+ * @property {number} bottom_of_conservation
+ * @property {number} bottom_of_flood
+ * @property {number} bottom_of_normal
+ * @property {number} design_capacity
+ * @property {string} level_type
+ * @property {number} stream_bed
+ * @property {number} top_of_conservation
+ * @property {number} top_of_dam
+ * @property {number} top_of_deadpool
+ * @property {number} top_of_flood
+ * @property {number} top_of_surcharge
+*/
+
+/**
+ * @typedef a2w.models.StreamLocation
+ * @property {string} office_id
+ * @property {string} public_name
+ * @property {string} location_code
+ * @property {string} location_id
+ * @property {number} station
+*/


### PR DESCRIPTION
#164 #166 wire up stream controls to change location and move upstream/downstream; swap upstream/downstream buttons; add `npm run remote` to use remote REST API during local dev. So if you run the app using `npm run remote`, it will try to use the live REST API we have at AWS. Obviously, that requires you to be on the VPN though.