### PR TITLE
#170 plot size tweaks

### DIFF
--- a/src/app-pages/map/components/location-details/LocationDetails.js
+++ b/src/app-pages/map/components/location-details/LocationDetails.js
@@ -30,41 +30,39 @@ const LocationDetails = ( props ) => {
   };
 
   if( locationDetailIsLoading ) return <Loader type={ loaderTypes.SPINNER }/>
-  else {
-    const detailSections = buildLocationDetailSections( locationDetail )
-    return (
-      <>
-        <LocationDetailHeader
-          locationDetail={ locationDetail }
-          onExpand={ handleFullScreen ? () => handleFullScreen( { selectedLocationCode: locationCode } ) : null }
-          getHeaderHeight={ getHeaderHeight }
-        />
-        <div className="location-detail-content-container">
-          { !handleFullScreen && (
-            <div className="map-details-nav">
-              {/* added 32 for padding*/ }
-              <ul className="navbar-ul fixed-sticky-nav" style={ { top: headerHeight + 32 } }>
-                { detailSections.map( ( section ) => {
-                  const { title } = section;
-                  return (
-                    <li className="nav-item" key={ title }>
-                      <button className="nav-link-btn" onClick={ () => handleNavClick( title ) }>
-                        { title }
-                      </button>
-                    </li>
-                  );
-                } )
-                }
-              </ul>
-            </div>
-          ) }
-          <div className="accordion-container">
-            <Accordion data={ detailSections } formatId={ formatId }/>
+  const detailSections = buildLocationDetailSections( locationDetail )
+  return (
+    <>
+      <LocationDetailHeader
+        locationDetail={ locationDetail }
+        onExpand={ handleFullScreen ? () => handleFullScreen( { selectedLocationCode: locationCode } ) : null }
+        getHeaderHeight={ getHeaderHeight }
+      />
+      <div className="location-detail-content-container">
+        { !handleFullScreen && (
+          <div className="map-details-nav">
+            {/* added 32 for padding*/ }
+            <ul className="navbar-ul fixed-sticky-nav" style={ { top: headerHeight + 32 } }>
+              { detailSections.map( ( section ) => {
+                const { title } = section;
+                return (
+                  <li className="nav-item" key={ title }>
+                    <button className="nav-link-btn" onClick={ () => handleNavClick( title ) }>
+                      { title }
+                    </button>
+                  </li>
+                );
+              } )
+              }
+            </ul>
           </div>
+        ) }
+        <div className="accordion-container">
+          <Accordion data={ detailSections } formatId={ formatId }/>
         </div>
-      </>
-    )
-  };
+      </div>
+    </>
+  );
 };
 
 LocationDetails.propTypes = {

--- a/src/app-pages/map/components/location-details/LocationDetails.js
+++ b/src/app-pages/map/components/location-details/LocationDetails.js
@@ -3,58 +3,68 @@ import PropTypes from "prop-types";
 import Accordion from "../../../../app-common/accordion/Accordion";
 import Loader, { loaderTypes } from "../../../../app-common/loader/Loader";
 import LocationDetailHeader from "./components/LocationDetailHeader";
-import { accordionArrObjs } from "./data";
+import { buildLocationDetailSections } from "./data";
 
-const LocationDetails = ({ handleFullScreen, locationDetail, locationCode, locationDetailIsLoading }) => {
+const LocationDetails = ( props ) => {
+  const {
+    handleFullScreen,
+    /** @type a2w.models.LocationDetail */
+    locationDetail,
+    locationCode,
+    locationDetailIsLoading
+  } = props;
 
-  const [headerHeight, setHeaderHeight] = useState(null);
-  const formatId = (title) => {
-    return title && title.toLowerCase().replace(" ", "_");
+  const [ headerHeight, setHeaderHeight ] = useState( null );
+  const formatId = ( title ) => {
+    return title && title.toLowerCase().replace( " ", "_" );
   };
-  const getHeaderHeight = useCallback( (refHeight) =>{
-    setHeaderHeight(refHeight);
+  const getHeaderHeight = useCallback( ( refHeight ) => {
+    setHeaderHeight( refHeight );
   }, [ setHeaderHeight ] );
 
-  const handleNavClick = (title) => {
-    const accordionBtnId = formatId(title);
+  const handleNavClick = ( title ) => {
+    const accordionBtnId = formatId( title );
     //added 10 for a little more padding
-    const topOfElement = document.getElementById(accordionBtnId).offsetTop - (headerHeight + 10);
-    window.scroll({ top: topOfElement, behavior: "smooth" });
+    const topOfElement = document.getElementById( accordionBtnId ).offsetTop - ( headerHeight + 50 );
+    window.scroll( { top: topOfElement, behavior: "smooth" } );
   };
 
-  if( locationDetailIsLoading ) return <Loader type={loaderTypes.SPINNER} />
-  else return (
-    <>
-      <LocationDetailHeader
-        locationDetail={locationDetail}
-        onExpand={handleFullScreen ? () => handleFullScreen({selectedLocationCode:locationCode}) : null}
-        getHeaderHeight = { getHeaderHeight }
-      />
-      <div className="location-detail-content-container">
-        {!handleFullScreen && (
-          <div className="map-details-nav">
-            {/* added 32 for padding*/}
-            <ul className="navbar-ul fixed-sticky-nav" style={{ top:headerHeight + 32 }}>
-              { accordionArrObjs.map((section) => {
+  if( locationDetailIsLoading ) return <Loader type={ loaderTypes.SPINNER }/>
+  else {
+    const detailSections = buildLocationDetailSections( locationDetail )
+    return (
+      <>
+        <LocationDetailHeader
+          locationDetail={ locationDetail }
+          onExpand={ handleFullScreen ? () => handleFullScreen( { selectedLocationCode: locationCode } ) : null }
+          getHeaderHeight={ getHeaderHeight }
+        />
+        <div className="location-detail-content-container">
+          { !handleFullScreen && (
+            <div className="map-details-nav">
+              {/* added 32 for padding*/ }
+              <ul className="navbar-ul fixed-sticky-nav" style={ { top: headerHeight + 32 } }>
+                { detailSections.map( ( section ) => {
                   const { title } = section;
                   return (
-                    <li className="nav-item" key={title}>
-                      <button className="nav-link-btn" onClick={() => handleNavClick(title)}>
-                        {title}
+                    <li className="nav-item" key={ title }>
+                      <button className="nav-link-btn" onClick={ () => handleNavClick( title ) }>
+                        { title }
                       </button>
                     </li>
                   );
-                })
-              }
-            </ul>
+                } )
+                }
+              </ul>
+            </div>
+          ) }
+          <div className="accordion-container">
+            <Accordion data={ detailSections } formatId={ formatId }/>
           </div>
-        )}
-        <div className="accordion-container">
-          <Accordion data={accordionArrObjs} formatId={formatId} />
         </div>
-      </div>
-    </>
-  );
+      </>
+    )
+  };
 };
 
 LocationDetails.propTypes = {

--- a/src/app-pages/map/components/location-details/components/time-series/TimeSeriesSection.js
+++ b/src/app-pages/map/components/location-details/components/time-series/TimeSeriesSection.js
@@ -28,7 +28,8 @@ const TimeSeriesSection = ({
   }
 
   const layout = {
-    width: "100%",
+    autosize: true,
+    margin: { t: 70, b: 50, l: 70, r: 70 },
     title: data[plotIndex].name,
     yaxis: {
       title: data[plotIndex].unit,
@@ -47,6 +48,7 @@ const TimeSeriesSection = ({
           data={[ data[plotIndex] ]}
           layout={layout}
           config={config}
+          useResizeHandler={ true }
         />
         <TimeSeriesControl />
       </div>

--- a/src/app-pages/map/components/location-details/components/time-series/time-series.scss
+++ b/src/app-pages/map/components/location-details/components/time-series/time-series.scss
@@ -1,15 +1,25 @@
 .time-series-section {
   display: flex;
   flex-wrap: wrap;
-  overflow: scroll;
+  overflow-y: auto;
 }
 
 .time-series-plot {
   flex-grow: 1;
 }
 
+.js-plotly-plot {
+  width: 100%;
+  min-width: 100%;
+}
+
+.plot-container {
+  width: 100%;
+}
+
 .time-series-control {
   display: flex;
+  position: static;
   flex-wrap: wrap;
   >p {
     font-weight: 700;

--- a/src/app-pages/map/components/location-details/data.js
+++ b/src/app-pages/map/components/location-details/data.js
@@ -4,31 +4,43 @@ import LocationInfo from "./components/LocationInfo";
 import TimeSeriesSection from "./components/time-series/TimeSeriesSection";
 import TimeLineSection from "./components/TimeLineSection";
 
-// Accordion dummy data
-export const accordionArrObjs = [
-  {
+const sectionConfigs = {
+  damProfile: {
     title: "Dam Profile",
     content: <DamProfile />,
     iconClass: "mdi mdi-water-pump",
   },
-  {
+  locationInfo: {
     title: "Location Information",
-    content: <LocationInfo />,
+      content: <LocationInfo />,
     iconClass: "mdi mdi-map-marker",
   },
-  {
+  timeSeries: {
     title: "Time Series",
-    content: <TimeSeriesSection/>,
+      content: <TimeSeriesSection/>,
     iconClass: "mdi mdi-chart-timeline",
   },
-  {
+  timeline: {
     title: "TimeLine",
-    content: <TimeLineSection/>,
+      content: <TimeLineSection/>,
     iconClass: "mdi mdi-chart-timeline",
   },
-  {
+  sedimentation: {
     title: "Sedimentation",
-    content: "Lorem 2 ipsum dolor sit amet, consectetur adipiscing elit, sed do ddd.",
+      content: "Lorem 2 ipsum dolor sit amet, consectetur adipiscing elit, sed do ddd.",
     iconClass: "mdi mdi-map-marker",
-  },
-];
+  }
+}
+
+export function buildLocationDetailSections( /** @type a2w.models.LocationDetail */ locationDetail ) {
+  const result = [];
+  if( !locationDetail ) return result;
+
+  if( locationDetail.dam_indicator === "T" ) result.push( sectionConfigs.damProfile );
+  result.push( sectionConfigs.locationInfo );
+  result.push( sectionConfigs.timeSeries );
+  result.push( sectionConfigs.timeline );
+  //result.push( sectionConfigs.sedimentation );
+
+  return result;
+}


### PR DESCRIPTION
This builds the detail sections dynamically, so we can add or omit sections depending on the location detail data. It also tries to use more width on the full-page location detail.

There is an odd issue with Plotly where the initial plot doesn't use the full width, but once you change the plot, it resizes to use the available width. I tried a few things to kick it into gear (updating the revision, etc.), but I think it has to do with the fact that the plot is created while the section is collapsed, so Plotly's initial sizing of the plot is wrong. Maybe we need a flag to pass in to tell the component it is collapsed or expanded, so that it only creates the plot once it is expanded. We can look into that later. 