### PR TITLE
#170 time series plot sizing

### DIFF
--- a/src/app-common/accordion/Accordion.js
+++ b/src/app-common/accordion/Accordion.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { cloneElement, useState } from "react";
 import PropTypes from "prop-types";
 import "./accordion.scss";
 
@@ -43,7 +43,7 @@ const Accordion = ({ data, formatId }) => {
                 aria-hidden={ !activeAcc[i] }
               >
                 <div className="content-paragraph">
-                  { content }
+                  { cloneElement( content, { visible: !!activeAcc[ i ] } ) }
                 </div>
               </div>
             </div>

--- a/src/app-common/accordion/Accordion.js
+++ b/src/app-common/accordion/Accordion.js
@@ -1,4 +1,4 @@
-import React, { cloneElement, useState } from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import "./accordion.scss";
 
@@ -43,7 +43,7 @@ const Accordion = ({ data, formatId }) => {
                 aria-hidden={ !activeAcc[i] }
               >
                 <div className="content-paragraph">
-                  { cloneElement( content, { visible: !!activeAcc[ i ] } ) }
+                  { activeAcc[ i ] && content }
                 </div>
               </div>
             </div>

--- a/src/app-common/accordion/Accordion.js
+++ b/src/app-common/accordion/Accordion.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { cloneElement, isValidElement, useState } from "react";
 import PropTypes from "prop-types";
 import "./accordion.scss";
 
@@ -15,41 +15,46 @@ const Accordion = ({ data, formatId }) => {
 
   return (
     <div className="accordion-section">
-      { data && data.map((ele, i) => {
-          const { content, title, iconClass } = ele;
-          return (
-            <div key={ title }>
-              <button
-                className="accordion-btn"
-                onClick={ e => toggleAccordion(e, i) }
-                aria-controls={ `accordion-control-${i}` }
-                aria-expanded={ !!activeAcc[i] }
-                type="button"
-              >
-                <div
-                  id={ formatId(title) }
-                  className={ `accordion-title text--bold ${iconClass}` }
-                >
-                  { title }
-                </div>
-                <div
-                  className={ activeAcc[i] ? "chevron up" : "chevron down" }
-                />
-              </button>
+      { data && data.map((config, i) => {
+        const { content, title, iconClass, lazy } = config;
+
+        return (
+          <div key={ title }>
+            <button
+              className="accordion-btn"
+              onClick={ e => toggleAccordion(e, i) }
+              aria-controls={ `accordion-control-${i}` }
+              aria-expanded={ !!activeAcc[i] }
+              type="button"
+            >
               <div
-                id={ `accordion-control-${i}` }
-                className={ activeAcc[i] ? "accordion-content" : "accordion-content d-none" }
-                aria-labelledby={ title }
-                aria-hidden={ !activeAcc[i] }
+                id={ formatId(title) }
+                className={ `accordion-title text--bold ${iconClass}` }
               >
-                <div className="content-paragraph">
-                  { activeAcc[ i ] && content }
-                </div>
+                { title }
+              </div>
+              <div
+                className={ activeAcc[i] ? "chevron up" : "chevron down" }
+              />
+            </button>
+            <div
+              id={ `accordion-control-${i}` }
+              className={ activeAcc[i] ? "accordion-content" : "accordion-content d-none" }
+              aria-labelledby={ title }
+              aria-hidden={ !activeAcc[i] }
+            >
+              <div className="content-paragraph">
+                { isValidElement( content ) // content is a React element
+                  ? lazy !== true
+                    ? cloneElement( content, { visible: !!activeAcc[ i ] } )
+                    : activeAcc[ i ] && cloneElement( content, { visible: !!activeAcc[ i ] } )
+                  : content // content is a string
+                }
               </div>
             </div>
-          );
-        })
-      }
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/app-pages/map/components/location-details/components/time-series/TimeSeriesSection.js
+++ b/src/app-pages/map/components/location-details/components/time-series/TimeSeriesSection.js
@@ -9,8 +9,12 @@ import TimeSeriesTable from "./TimeSeriesTable";
 const TimeSeriesSection = ({
   locationTimeSeriesPlotlyData,
   locationTimeSeriesIsLoading,
+  visible
 }) => {
   const [plotIndex, setPlotIndex] = useState(0);
+
+  // TODO: remove, this is just to test that visibility prop is being passed in correctly
+  console.log( "time series visible?", visible );
 
   // reset the plotIndex when the plotly data changes
   useEffect(() => {

--- a/src/app-pages/map/components/location-details/components/time-series/TimeSeriesSection.js
+++ b/src/app-pages/map/components/location-details/components/time-series/TimeSeriesSection.js
@@ -9,12 +9,8 @@ import TimeSeriesTable from "./TimeSeriesTable";
 const TimeSeriesSection = ({
   locationTimeSeriesPlotlyData,
   locationTimeSeriesIsLoading,
-  visible
 }) => {
   const [plotIndex, setPlotIndex] = useState(0);
-
-  // TODO: remove, this is just to test that visibility prop is being passed in correctly
-  console.log( "time series visible?", visible );
 
   // reset the plotIndex when the plotly data changes
   useEffect(() => {


### PR DESCRIPTION
Using `cloneElement()` in the Accordion seems to allow passing in an additional `visible` prop, but also seems to make the chart's initial width get calculated correctly. Meaning the initial size is calculated correctly *without* me having to do anything with the `visible` prop. Does anyone see an issue with using `cloneElement()`? I'm not sure what the pros and cons of this are. 

From what I read, the other option to let a component append additional props to a "pass through" component is to pass in the constructor instead of an instance. e.g. pass in `TimeSeriesSection` instead of `<TimeSeriesSection/>, and then the accordion would create the instance and append the visible prop. So instead of the accordion just outputting `{content}`, it would do `<content visible={flag}/>`. 

But if either of you know of other ways to do this, just let me know.