### PR TITLE
add tests for the time series components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1441,7 +1441,8 @@
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -1556,6 +1557,7 @@
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
       "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@sheerun/mutationobserver-shim": "^0.3.2",
@@ -1570,6 +1572,7 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
           "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -1581,6 +1584,7 @@
           "version": "15.0.5",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
           "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -1589,6 +1593,7 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -1598,6 +1603,7 @@
           "version": "4.2.2",
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
           "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.10.2",
             "@babel/runtime-corejs3": "^7.10.2"
@@ -1607,6 +1613,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1616,6 +1623,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1623,17 +1631,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -1645,6 +1656,7 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -1655,6 +1667,7 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
       "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.1",
         "chalk": "^2.4.1",
@@ -1671,6 +1684,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
       "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4",
         "@testing-library/dom": "^6.15.0",
@@ -1680,7 +1694,8 @@
     "@testing-library/user-event": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
-      "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA=="
+      "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.9",
@@ -1717,6 +1732,15 @@
       "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/cheerio": {
+      "version": "0.22.22",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.22.tgz",
+      "integrity": "sha512-05DYX4zU96IBfZFY+t3Mh88nlwSMtmmzSYaQkKN48T495VV1dkHSah6qYyDTN5ngaS0i0VonH37m+RuzSM0YiA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/color-name": {
@@ -1889,7 +1913,8 @@
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1900,6 +1925,7 @@
       "version": "16.9.43",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
       "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -1909,6 +1935,7 @@
       "version": "16.9.8",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
       "integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -1922,6 +1949,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz",
       "integrity": "sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==",
+      "dev": true,
       "requires": {
         "pretty-format": "^24.3.0"
       }
@@ -1930,6 +1958,7 @@
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.3.tgz",
       "integrity": "sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==",
+      "dev": true,
       "requires": {
         "@types/react-dom": "*",
         "@types/testing-library__dom": "*",
@@ -1940,6 +1969,7 @@
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
           "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
             "@types/istanbul-reports": "^1.1.1",
@@ -1951,6 +1981,7 @@
           "version": "15.0.5",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
           "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -1959,6 +1990,7 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -1968,6 +2000,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1977,6 +2010,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1984,17 +2018,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "pretty-format": {
           "version": "25.5.0",
           "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
           "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
           "requires": {
             "@jest/types": "^25.5.0",
             "ansi-regex": "^5.0.0",
@@ -2006,6 +2043,7 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -4465,7 +4503,8 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "csscolorparser": {
       "version": "1.0.3",
@@ -4598,7 +4637,8 @@
     "csstype": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw=="
+      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
+      "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4950,7 +4990,8 @@
     "dom-accessibility-api": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
-      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA=="
+      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -5331,6 +5372,17 @@
       "requires": {
         "has": "^1.0.3",
         "object-is": "^1.0.2"
+      }
+    },
+    "enzyme-to-json": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.6.1.tgz",
+      "integrity": "sha512-15tXuONeq5ORoZjV/bUo2gbtZrN2IH+Z6DvL35QmZyKHgbY1ahn6wcnLd9Xv9OjiwbAXiiP8MRZwbZrCv1wYNg==",
+      "dev": true,
+      "requires": {
+        "@types/cheerio": "^0.22.22",
+        "lodash": "^4.17.15",
+        "react-is": "^16.12.0"
       }
     },
     "errno": {
@@ -9174,7 +9226,8 @@
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -12395,6 +12448,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -13930,6 +13984,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }
@@ -14765,7 +14820,8 @@
     "wait-for-expect": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
-      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "@corpsmap/create-auth-bundle": "^0.3.0",
     "@corpsmap/create-jwt-api-bundle": "^0.5.0",
     "@fullhuman/postcss-purgecss": "^2.3.0",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.5.0",
-    "@testing-library/user-event": "^7.2.1",
     "@types/jest": "^26.0.14",
     "@types/node": "^14.11.2",
     "autoprefixer": "^9.8.6",
@@ -60,7 +57,21 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.5.0",
+    "@testing-library/user-event": "^7.2.1",
     "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.2"
+    "enzyme-adapter-react-16": "^1.15.2",
+    "enzyme-to-json": "^3.6.1"
+  },
+  "jest": {
+    "coverageReporters": [
+      "html",
+      "text",
+      "lcov"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   }
 }

--- a/src/app-bundles/radar-time-series-bundle.js
+++ b/src/app-bundles/radar-time-series-bundle.js
@@ -115,7 +115,7 @@ export default createRestBundle( {
       "selectLocationTimeSeriesData",
       (locationTimeSeriesData) => {
         if (!locationTimeSeriesData || !locationTimeSeriesData["time-series"] || !locationTimeSeriesData["time-series"]["time-series"]) {
-          return [];
+          return {};
         }
 
         const plotlyArray = [];

--- a/src/app-pages/map/components/map-details/components/time-series/TimeSeriesDateRange.js
+++ b/src/app-pages/map/components/map-details/components/time-series/TimeSeriesDateRange.js
@@ -4,7 +4,7 @@ import { connect } from "redux-bundler-react";
 import { radarTimeControls } from "../../../../../../app-bundles/radar-time-series-bundle";
 import { dateToString } from "../../../../../../utils";
 
-const TimeSeriesDateRange = ({
+export const TimeSeriesDateRange = ({
   ltsTimeControl,
   ltsCustomStartDate,
   ltsCustomEndDate,
@@ -12,18 +12,14 @@ const TimeSeriesDateRange = ({
   doLtsSetCustomDate,
 }) => {
   const handleDateRangeOnChange = (e) => {
-    e.stopPropagation();
     doLtsSetTimeControl(parseInt(e.target.value));
   }
 
   const handleDateOnChange = (e) => {
-    e.stopPropagation();
     const name = e.target.name;
     const date = e.target.value;
     doLtsSetCustomDate(name, date);
   };
-
-  const handleOnClick = e => e.stopPropagation();
 
   const today = dateToString(new Date());
   return (
@@ -36,7 +32,6 @@ const TimeSeriesDateRange = ({
           id="timeControl"
           value={ltsTimeControl}
           onChange={handleDateRangeOnChange}
-          onClick={handleOnClick}
         >
           { radarTimeControls.map(({ value, label }) => (
             <option
@@ -62,7 +57,6 @@ const TimeSeriesDateRange = ({
               value={ltsCustomStartDate}
               max={ltsCustomEndDate || today}
               onChange={handleDateOnChange}
-              onClick={handleOnClick}
             />
           </div>
           <div className="time-series-input">
@@ -77,7 +71,6 @@ const TimeSeriesDateRange = ({
               max={today}
               min={ltsCustomStartDate}
               onChange={handleDateOnChange}
-              onClick={handleOnClick}
             />
           </div>
         </>

--- a/src/app-pages/map/components/map-details/components/time-series/TimeSeriesSection.js
+++ b/src/app-pages/map/components/map-details/components/time-series/TimeSeriesSection.js
@@ -6,7 +6,7 @@ import TimeSeriesDateRange from "./TimeSeriesDateRange";
 import TimeSeriesPlot from "./TimeSeriesPlot";
 import TimeSeriesPlotLegend from "./TimeSeriesPlotLegend";
 
-const TimeSeriesSection = ({
+export const TimeSeriesSection = ({
   queryObject,
   locationTimeSeriesPlotlyData,
   locationTimeSeriesIsLoading,
@@ -46,6 +46,7 @@ const TimeSeriesSection = ({
 };
 
 TimeSeriesSection.propTypes = {
+  queryObject: PropTypes.object.isRequired,
   locationTimeSeriesPlotlyData: PropTypes.object.isRequired,
   locationTimeSeriesIsLoading: PropTypes.bool.isRequired,
 };

--- a/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesDateRange.test.js
+++ b/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesDateRange.test.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { TIME } from "../../../../../../../utils";
+import { TimeSeriesDateRange } from "../TimeSeriesDateRange";
+
+describe("<TimeSeriesDateRange />", () => {
+  const renderOptions = { disableLifecycleMethods: true };
+  const baseProps = {
+    ltsTimeControl: TIME.WEEK,
+    ltsCustomStartDate: "",
+    ltsCustomEndDate: "",
+    doLtsSetTimeControl: jest.fn(),
+    doLtsSetCustomDate: jest.fn(),
+  };
+
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<TimeSeriesDateRange {...baseProps} />, renderOptions);
+  });
+
+  it("should render date range", () => {
+    expect(wrapper.find("label").length).toBe(1);
+    expect(wrapper.find("label").props().children).toBe("Date Range");
+  });
+
+  it("should render start and end date selectors", () => {
+    wrapper.setProps({ ltsTimeControl: -1 })
+    expect(wrapper.find("label").length).toBe(3);
+    expect(wrapper.find("label").at(1).props().children).toBe("Start Date");
+    expect(wrapper.find("label").at(2).props().children).toBe("End Date");
+  });
+
+  it("should update the date range", () => {
+    const doLtsSetTimeControl = jest.fn();
+    wrapper.setProps({ doLtsSetTimeControl });
+
+    const mockEvent = {
+      target: { value: `${TIME.MONTH}` },
+    }
+    wrapper.find("select").prop("onChange")(mockEvent);
+    expect(doLtsSetTimeControl).toHaveBeenCalledWith(TIME.MONTH);
+  });
+
+  it("should update the start and end dates", () => {
+    const doLtsSetCustomDate = jest.fn();
+    wrapper.setProps({ doLtsSetCustomDate, ltsTimeControl: -1 });
+
+    // change the start date
+    const mockStartDate = {
+      target: {
+        name: "customStartDate",
+        value: "2020-11-01",
+      },
+    };
+    wrapper.find("input").at(0).prop("onChange")(mockStartDate);
+    expect(doLtsSetCustomDate).toHaveBeenCalledWith(mockStartDate.target.name, mockStartDate.target.value);
+
+    // change the end date
+    const mockEndDate = {
+      target: {
+        name: "customEndDate",
+        value: "2020-11-30",
+      },
+    };
+    wrapper.find("input").at(0).prop("onChange")(mockEndDate);
+    expect(doLtsSetCustomDate).toHaveBeenCalledWith(mockEndDate.target.name, mockEndDate.target.value);
+  });
+});

--- a/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesPlot.test.js
+++ b/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesPlot.test.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { shallow } from "enzyme";
+import TimeSeriesPlot from "../TimeSeriesPlot";
+import { mockLocationTimeSeriesPlotlyData } from "./mocks";
+
+describe("<TimeSeriesPlot />", () => {
+  const renderOptions = { disableLifecycleMethods: true };
+  const baseProps = {
+    locationTimeSeriesPlotlyData: mockLocationTimeSeriesPlotlyData,
+    plotName: "plot1",
+    plotHeight: 300,
+  };
+
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<TimeSeriesPlot {...baseProps} />, renderOptions);
+  });
+
+  it("should render plot", () => {
+    expect(wrapper.find("PlotlyComponent").length).toBe(1);
+  });
+
+  it("should display 'No Data' if locationTimeSeriesPlotlyData is null", () => {
+    wrapper.setProps({ locationTimeSeriesPlotlyData: null });
+    expect(wrapper.find("p").props().children).toBe("No data for the selected date range.");
+  });
+
+  it("should display 'No Data' if locationTimeSeriesPlotlyData is empty object", () => {
+    wrapper.setProps({ locationTimeSeriesPlotlyData: {} });
+    expect(wrapper.find("p").props().children).toBe("No data for the selected date range.");
+  });
+
+  it("should not render anything if locationTimeSeriesPlotlyData does not contain the plotName", () => {
+    wrapper.setProps({ plotName: "newPlotWhoDis" });
+    expect(wrapper.find("PlotlyComponent").length).toBe(0);
+    expect(wrapper.find("p").length).toBe(0);
+  });
+});

--- a/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesPlotLegend.test.js
+++ b/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesPlotLegend.test.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { shallow } from "enzyme";
+import TimeSeriesPlotLegend from "../TimeSeriesPlotLegend";
+import { mockLocationTimeSeriesPlotlyData } from "./mocks";
+
+describe("<TimeSeriesPlotLegend />", () => {
+  const renderOptions = { disableLifecycleMethods: true };
+  const baseProps = {
+    locationTimeSeriesPlotlyData: mockLocationTimeSeriesPlotlyData,
+    plotName: "plot1",
+    setPlotName: jest.fn(),
+  };
+
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<TimeSeriesPlotLegend {...baseProps} />, renderOptions);
+  });
+
+  it("should render plot", () => {
+    expect(wrapper.find("table").length).toBe(1);
+  });
+
+  it("should not render anything if locationTimeSeriesPlotlyData is null", () => {
+    wrapper.setProps({ locationTimeSeriesPlotlyData: null });
+    expect(wrapper.find("table").length).toBe(0);
+  });
+
+  it("should not render anything if locationTimeSeriesPlotlyData is empty object", () => {
+    wrapper.setProps({ locationTimeSeriesPlotlyData: {} });
+    expect(wrapper.find("table").length).toBe(0);
+  });
+
+  it("should call setPlotName if a table row is clicked", () => {
+    const setPlotName = jest.fn();
+    wrapper.setProps({ setPlotName });
+
+    // sumulate clicking the second table row
+    wrapper.find("tr").at(2).prop("onClick")();
+
+    expect(setPlotName).toBeCalledWith("plot2");
+  });
+});

--- a/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesSection.test.js
+++ b/src/app-pages/map/components/map-details/components/time-series/tests/TimeSeriesSection.test.js
@@ -1,0 +1,118 @@
+import React from "react";
+import { shallow, mount } from "enzyme";
+import { act } from "react-dom/test-utils";
+import { Provider } from "redux-bundler-react";
+import { composeBundles, createRouteBundle } from "redux-bundler";
+import radarTimeSeriesBundle from "../../../../../../../app-bundles/radar-time-series-bundle";
+import { TimeSeriesSection } from "../TimeSeriesSection";
+import { mockLocationTimeSeriesPlotlyData } from "./mocks";
+
+describe("<TimeSeriesSection />", () => {
+  const renderOptions = { disableLifecycleMethods: true };
+  const baseProps = {
+    queryObject: {},
+    locationTimeSeriesPlotlyData: mockLocationTimeSeriesPlotlyData,
+    locationTimeSeriesIsLoading: false,
+  };
+
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<TimeSeriesSection {...baseProps} />, renderOptions);
+  });
+
+  it("should render component", () => {
+    expect(wrapper.find("Loader").length).toBe(0);
+    expect(wrapper.find("TimeSeriesPlot").length).toBe(1);
+    expect(wrapper.find("connect(TimeSeriesDateRange)").length).toBe(1);
+    expect(wrapper.find("TimeSeriesPlotLegend").length).toBe(1);
+  });
+
+  it("should render loader", () => {
+    wrapper.setProps({ locationTimeSeriesIsLoading: true });
+    expect(wrapper.find("Loader").length).toBe(1);
+  });
+
+  it("should set plot height to 450 if display is full screen", () => {
+    wrapper.setProps({
+      queryObject: { display: "fs" },
+    });
+    expect(wrapper.find("TimeSeriesPlot").prop("plotHeight")).toBe(450);
+  });
+
+  describe("test useEffect()", () => {
+    const store = composeBundles(
+      createRouteBundle({}),
+      radarTimeSeriesBundle,
+      {
+        name: "mock",
+        selectAuthRoles: () => [],
+        selectLocationDetailData: () => {},
+      }
+    )();
+
+    const Proxy = (props) => (
+      <Provider store={store}>
+        <TimeSeriesSection {...props} />
+      </Provider>
+    );
+    beforeEach(() => {
+      wrapper = mount(<Proxy {...baseProps} />);
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
+    })
+
+    it("should set plotName to the first plot when the locationTimeSeriesPlotlyData loads", () => {
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot1");
+    });
+
+    it("should update plotName via setPlotName", async () => {
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot1");
+      await act(async () => {
+        wrapper.find("TimeSeriesPlotLegend").prop("setPlotName")("plot3")
+      });
+      wrapper.update();
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot3");
+    });
+
+    it("should update plotName to the first plot in locationTimeSeriesPlotlyData if locationTimeSeriesPlotlyData changes", async () => {
+      // initially plotName should be "plot1"
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot1");
+
+      // change locationTimeSeriesPlotlyData data
+      await act(async () => {
+        wrapper.setProps({
+          locationTimeSeriesPlotlyData: {
+            "plot4": {
+              name: "plot4",
+              x: [],
+              y: [],
+            },
+            "plot5": {
+              name: "plot5",
+              x: [],
+              y: [],
+            },
+          },
+        });
+      });
+      wrapper.update();
+
+      // plotName should be plot4
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot4");
+    });
+
+    it("should not update plotName if locationTimeSeriesPlotlyData is an empty object", async () => {
+      // initially plotName should be "plot1"
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot1");
+
+      // change locationTimeSeriesPlotlyData to an empty object
+      await act(async () => {
+        wrapper.setProps({ locationTimeSeriesPlotlyData: {} });
+      });
+      wrapper.update();
+      expect(wrapper.find("TimeSeriesPlot").prop("plotName")).toBe("plot1");
+    });
+  });
+});

--- a/src/app-pages/map/components/map-details/components/time-series/tests/mocks.js
+++ b/src/app-pages/map/components/map-details/components/time-series/tests/mocks.js
@@ -1,0 +1,17 @@
+export const mockLocationTimeSeriesPlotlyData = {
+  "plot1": {
+    name: "plot1",
+    x: [],
+    y: [],
+  },
+  "plot2": {
+    name: "plot2",
+    x: [],
+    y: [],
+  },
+  "plot3": {
+    name: "plot3",
+    x: [],
+    y: [],
+  },
+};


### PR DESCRIPTION
I moved all the testing libraries into the dev dependencies since they're not needed to build the actual app. I also added this library called `enzyme-to-json` which is helpful if you want to see what your tests are rendering.
For example if you do
```
const wrapper = shallow(<TimeSeriesSection />, renderOptions);
expect(wrapper).toMatchSnapshot();
```
the snapshot will be an empty object. But by importing the `enzyme-to-json` the snapshot will be serialized and display the underlying html elements. Snapshot tests themselves aren't that useful imo, but I find them helpful when debugging my tests. Also, in case you don't know, you can run `npm run test -- --coverage` and it will produce an html output of the code coverage for the entire project, you can view it under coverage/index.html.