### PR TITLE
#195 fix issue with autocomplete dropdown stacking

### DIFF
--- a/src/app-common/inputs/Dropdown.js
+++ b/src/app-common/inputs/Dropdown.js
@@ -6,7 +6,7 @@ const clearButtonCss = {
   float: "right",
   fontSize: "1.4em",
   marginRight: "1.5rem",
-  marginTop: "-2rem",
+  marginTop: "-1.4em",
   cursor: "pointer",
   color: "#333333"
 }

--- a/src/app-common/inputs/autocomplete/Autocomplete.js
+++ b/src/app-common/inputs/autocomplete/Autocomplete.js
@@ -145,7 +145,7 @@ const Autocomplete = (props) => {
         {...input}
         {...rest}
         id={id}
-        type="text"
+        type="text" autoComplete="off"
         onClick={handleInputOnClick}
         onKeyDown={handleInputOnKeyDown}
         aria-haspopup="true"

--- a/src/app-common/tree-menu/treeMenu.scss
+++ b/src/app-common/tree-menu/treeMenu.scss
@@ -24,7 +24,7 @@
 }
 
 .rstm-tree-item {
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 1rem;
   cursor: pointer;
   color: $base-dark-gray;
   background: none;

--- a/src/app-common/tree-menu/treeMenu.scss
+++ b/src/app-common/tree-menu/treeMenu.scss
@@ -21,14 +21,15 @@
   position: absolute;
   overflow: auto;
   max-height: 75vh;
+  padding-bottom: 0.25rem;
+  border-radius: 0px 0px 5px 5px;
 }
 
 .rstm-tree-item {
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 1rem;
   cursor: pointer;
   color: $base-dark-gray;
   background: none;
-  height: $default-input-height;
   box-shadow: none;
   z-index: unset;
   position: relative;
@@ -60,5 +61,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 600px;
+    vertical-align: middle;
   }
 }

--- a/src/app-pages/home/homePage.scss
+++ b/src/app-pages/home/homePage.scss
@@ -30,6 +30,7 @@
       border: 2px solid rgba(255,255,255,0.9);
       background-clip: padding-box;
       padding-bottom: 0.8rem !important;
+      z-index: 2000;
 
       @include mq($breakpoint: "phone-lg", $direction: "down") {
         transform: translateY(0);

--- a/src/app-pages/map/components/map-navbar/mapNavbar.scss
+++ b/src/app-pages/map/components/map-navbar/mapNavbar.scss
@@ -2,7 +2,6 @@
 
 .map-navbar {
   .form-control {
-    height: $default-input-height;
     color: $base-gray;
   }
   .form-group {

--- a/src/style/sass/abstracts/_variables.scss
+++ b/src/style/sass/abstracts/_variables.scss
@@ -31,7 +31,6 @@ $primary-red-darkest: #170305;
 $base-font:'Roboto', sans-serif;
 
 //sizing
-$default-input-height: 40.9766px;
 $icon-size: 1.5rem;
 $map-height: 80vh;
 $map-details-width: 600px;


### PR DESCRIPTION
Also, minor fixes to properly position dropdown clear button and tree item padding; turn off browser autocomplete for autocomplete component (double option list appearing is confusing).

Issue with the stacking was that using the background blur changes the stacking context, so I just needed to set a z-index on the parent.

We have a SCSS variable ($default-input-height) for input height that seems set to an odd value of 40.9766px. The Bootstrap theme already has built-in sizing for form-control elements, so not sure we want or need this variable? It seems confusing, since unless a component explicitly sets the height of something to this variable, it will use the Bootstrap form-control height. Right now the only place $default-input-height is used is to set the height of the tree items, which we could just set directly. 

Thoughts? Should I remove $default-input-height?